### PR TITLE
fix: target_name not defined

### DIFF
--- a/lambench/tasks/base_task.py
+++ b/lambench/tasks/base_task.py
@@ -12,7 +12,6 @@ class BaseTask(BaseModel):
     model_config = ConfigDict(extra='allow')
     workdir: Path = Path(tempfile.gettempdir()) / "lambench"
     record_type: ClassVar = BaseRecord
-    target_name: str
 
     def exist(self, model_name: str) -> bool:
         num_records = self.record_type.count(

--- a/lambench/tasks/direct/direct_predict.py
+++ b/lambench/tasks/direct/direct_predict.py
@@ -12,5 +12,5 @@ class DirectPredictTask(BaseTask):
     record_type: ClassVar = DirectPredictRecord
 
     def __init__(self, task_name: str, **kwargs):
-        super().__init__(task_name=task_name, test_data=kwargs["test_data"], target_name="standard")
+        super().__init__(task_name=task_name, test_data=kwargs["test_data"])
         # self.test_file_path = self.prepare_test_data()

--- a/lambench/tasks/finetune/property_finetune.py
+++ b/lambench/tasks/finetune/property_finetune.py
@@ -14,14 +14,14 @@ class PropertyFinetuneTask(BaseTask):
     """
 
     record_type: ClassVar = PropertyRecord
-    property_name: str
+    property_name: str  # The name of the property to be finetuned, e.g. dielectric
     intensive: bool = True
     property_dim: int = 1
     train_data: Path
     train_steps: int = 1000
 
     def __init__(self, task_name: str, **kwargs):
-        super().__init__(task_name=task_name, **kwargs, target_name="finetune")
+        super().__init__(task_name=task_name, **kwargs)
 
     def evaluate(self, model: BaseLargeAtomModel):
         self.get_property_json()


### PR DESCRIPTION
I think target_name is optional for direct_predict_tasks. Initially, I was trying to use this var to differentiate task types, but now we have record_type. This PR removes it.