### PR TITLE
Feature: add arguments selecting models and tasks

### DIFF
--- a/lambench/workflow/entrypoint.py
+++ b/lambench/workflow/entrypoint.py
@@ -1,7 +1,8 @@
+import argparse
 import logging
 import traceback
 from pathlib import Path
-from typing import Type
+from typing import Optional, Type
 
 import yaml
 
@@ -17,7 +18,9 @@ FINETUNE_TASKS = Path(lambench.__file__).parent / "tasks/finetune/finetune_tasks
 MODELS = Path(lambench.__file__).parent / "models/models_config.yml"
 
 
-def gather_models() -> list[BaseLargeAtomModel]:
+def gather_models(
+    model_names: Optional[list[str]] = None,
+) -> list[BaseLargeAtomModel]:
     """
     Gather models from the models_config.yml file.
     """
@@ -26,6 +29,8 @@ def gather_models() -> list[BaseLargeAtomModel]:
     with open(MODELS, "r") as f:
         model_config = yaml.safe_load(f)
     for model_name, model_param in model_config.items():
+        if model_names and model_name not in model_names:
+            continue
         if model_param["model_type"] == "DP":
             models.append(DPModel(**model_param))
         elif model_param["model_type"] == "ASE":
@@ -35,7 +40,10 @@ def gather_models() -> list[BaseLargeAtomModel]:
     return models
 
 def gather_task_type(
-    models: list[BaseLargeAtomModel], task_file: Path, task_class: Type[BaseTask]
+    models: list[BaseLargeAtomModel],
+    task_file: Path,
+    task_class: Type[BaseTask],
+    task_names: Optional[list[str]] = None,
 ) -> list[tuple[BaseTask, BaseLargeAtomModel]]:
     """
     Gather tasks of a specific type from the task file.
@@ -47,29 +55,38 @@ def gather_task_type(
         if isinstance(model, ASEModel) and not issubclass(task_class, DirectPredictTask):
             continue  # ASEModel only supports DirectPredictTask
         for task_name, task_param in task_configs.items():
+            if task_names and task_name not in task_names:
+                continue
             task = task_class(task_name=task_name, **task_param)
             if not task.exist(model.model_name):
                 tasks.append((task, model))
     return tasks
 
-def gather_jobs():
+def gather_jobs(
+    model_names: Optional[list[str]] = None,
+    task_names: Optional[list[str]] = None,
+):
     jobs = []
 
-    models = gather_models()
+    models = gather_models(model_names)
     if not models:
         logging.warning("No models found, skipping task gathering.")
         return jobs
 
     logging.info(f"Found {len(models)} models, gathering tasks.")
-    jobs.extend(gather_task_type(models, DIRECT_TASKS, DirectPredictTask))
-    # jobs.extend(gather_task_type(models, FINETUNE_TASKS, PropertyFinetuneTask)) # Not implemented yet
-
+    jobs.extend(gather_task_type(models, DIRECT_TASKS, DirectPredictTask, task_names))
+    # jobs.extend(gather_task_type(models, FINETUNE_TASKS, PropertyFinetuneTask, task_names)) # Not implemented yet
     return jobs
 
 def main():
+    parser = argparse.ArgumentParser(description="Run tasks for models.")
+    parser.add_argument("--models", type=str, nargs="*", help="The model names in `models_config.yml`. e.g. --models DP_2024Q4 MACE_MP_0 SEVENNET_0")
+    parser.add_argument("--tasks", type=str, nargs="*", help="The task names in `direct_tasks.yml` or `finetune_tasks.yml`. e.g. --tasks HPt_NC_2022 Si_ZEO22")
+    args = parser.parse_args()
+
     logging.basicConfig(level=logging.INFO)
 
-    jobs = gather_jobs()
+    jobs = gather_jobs(model_names=args.models, task_names=args.tasks)
     for task, model in jobs:
         logging.info(f"Running task={task.task_name}, model={model.model_name}")
         submit_job(task, model)
@@ -83,5 +100,6 @@ def submit_job(task, model):
     except Exception as _:
         traceback.print_exc()
         logging.error(f"task={task.task_name}, model={model.model_name} failed!")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
e.g. `lambench --models DP_2024Q4 MACE_MP_0 SEVENNET_0 --tasks HPt_NC_2022 Si_ZEO22`
These arguments are optional. The default behavior of collecting all available models and tasks is not changed in this PR.
Please note that the model names and task names must be exactly the same with their definition in yaml config files. This is for the simplicity when developing it.