### PR TITLE
Feature: add error handling for ASE models

### DIFF
--- a/lambench/models/ase_models.py
+++ b/lambench/models/ase_models.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 from ase.calculators.calculator import Calculator
 from ase.io import write
+from tqdm import tqdm
 
 from lambench.models.basemodel import BaseLargeAtomModel
 from lambench.tasks.direct.direct_tasks import DirectPredictTask
@@ -90,15 +91,14 @@ class ASEModel(BaseLargeAtomModel):
         assert systems, f"No systems found in the test data {test_data}."
         mix_type = any(systems[0].rglob("real_atom_types.npy"))
 
-        for filepth in systems:
+        for filepth in tqdm(systems, desc="Systems"):
             if mix_type:
                 sys = dpdata.MultiSystems()
                 sys.load_systems_from_file(filepth, fmt="deepmd/npy/mixed")
             else:
                 sys = dpdata.LabeledSystem(filepth, fmt="deepmd/npy")
-
-            for ls in sys:
-                for frame in ls:
+            for ls in tqdm(sys, desc="Set", leave=False):  # type: ignore
+                for frame in tqdm(ls, desc="Frames", leave=False):
                     atoms: ase.Atoms = frame.to_ase_structure()[0]  # type: ignore
                     atoms.calc = calc
 


### PR DESCRIPTION
This pull request includes several changes to the `lambench/models/ase_models.py` file, focusing on improving model path handling, adding error handling, and introducing new variables for failure tolerance.

Improvements to model path handling:

* Replaced hardcoded model paths with `self.model_path` in the `evaluate` method to ensure dynamic model path assignment. [[1]](diffhunk://#diff-819d60f73d52770904af054b2a60bbca2d76f82bc3d8f7cb5be6c15b4887dc2fL50-R51) [[2]](diffhunk://#diff-819d60f73d52770904af054b2a60bbca2d76f82bc3d8f7cb5be6c15b4887dc2fL68-R69)

Error handling enhancements:

* Added a try-except block in the `run_ase_dptest` function to handle non-finite energy predictions and save error information to a CIF file.

New variables for failure management:

* Introduced `fail_count` and `fail_tolereance` variables in the `run_ase_dptest` function to manage and limit the number of tolerated failures.

Additional imports:

* Added import for `write` from `ase.io` to enable writing CIF files in case of errors.