### PR TITLE
fix: use canonical 7net name using hyphen instead of underscore

### DIFF
--- a/lambench/models/ase_models.py
+++ b/lambench/models/ase_models.py
@@ -39,7 +39,7 @@ class ASEModel(BaseLargeAtomModel):
         elif self.model_family == "SevenNet":
             from sevenn.sevennet_calculator import SevenNetCalculator
 
-            # model_name in ["7net_0" (i.e. 7net_0_11july2024), "7net_0_22may2024", "7net-l3i5"]
+            # model_name in ["7net-0" (i.e. 7net-0_11july2024), "7net-0_22may2024", "7net-l3i5"]
             return SevenNetCalculator(self.model_name, device="cuda")
         elif self.model_family == "EquiformerV2":
             from fairchem.core import OCPCalculator

--- a/lambench/models/models_config.yml
+++ b/lambench/models/models_config.yml
@@ -22,7 +22,7 @@
   model_metadata:
     model_description: https://orbitalmaterials-public-models.s3.us-west-1.amazonaws.com/forcefields/orb-v2-20241011.ckpt
 
-- model_name: 7net_0
+- model_name: 7net-0
   model_type: ASE
   model_family: SevenNet
   virtualenv: sevennet


### PR DESCRIPTION
Requires an update to the existed records.