### PR TITLE
fix: update dpdata dependency to a release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 	"pyyaml",
 	"SQLAlchemy[pymysql]",
 	"tqdm",
-	"dpdata @ git+https://github.com/deepmodeling/dpdata.git@944af9dfbe0a6ae78d87a189a589d7614cbd8989#egg=dpdata",
+	"dpdata >= 0.2.22",
 ]
 
 authors = [


### PR DESCRIPTION
`dpdata 0.2.22` contains bug fixes from the following PRs.
https://github.com/deepmodeling/dpdata/pull/780
https://github.com/deepmodeling/dpdata/pull/772
https://github.com/deepmodeling/dpdata/pull/786/commits/4e5ab18b782f830e261c747f475998b8b4f92f3b