### PR TITLE
Fix: sync activation func for property fine-tuning

### DIFF
--- a/lambench/tasks/finetune/property_finetune.py
+++ b/lambench/tasks/finetune/property_finetune.py
@@ -87,6 +87,13 @@ class PropertyFinetuneTask(BaseTask):
         descriptor = PropertyFinetuneTask._find_value_by_key_pattern(
             pretrain_config["model"]["shared_dict"], "descriptor"
         )
+
+        # update activation function of the fitting net to match the descriptor
+        if "activation_function" in descriptor:
+            finetune_config["model"]["fitting_net"]["activation_function"] = descriptor[
+                "activation_function"
+            ]
+
         finetune_config["model"]["descriptor"] = descriptor
         finetune_config["model"]["type_map"] = pretrain_config["model"]["shared_dict"][
             "type_map_all"


### PR DESCRIPTION
This PR changes the activation function used in property fine-tuning to match the descriptor.
Previously a default `tanh` was used.