### PR TITLE
Add additional unit tests

### DIFF
--- a/tests/metrics/test_utils_extra.py
+++ b/tests/metrics/test_utils_extra.py
@@ -1,0 +1,75 @@
+import numpy as np
+from lambench.metrics.utils import (
+    filter_generalizability_force_field_results,
+    aggregated_inference_efficiency_results,
+    get_domain_to_direct_task_mapping,
+)
+
+
+def test_filter_generalizability_force_field_results():
+    task_result = {
+        "energy_rmse": 0.2,
+        "force_rmse": 0.3,
+        "virial_rmse": 0.4,
+    }
+    config = {
+        "energy_weight": 1.0,
+        "force_weight": 0.5,
+        "virial_weight": None,
+        "energy_std": 1.0,
+        "force_std": 1.0,
+        "virial_std": 1.0,
+    }
+    res = filter_generalizability_force_field_results(task_result, config)
+    assert np.isclose(res["energy_rmse"], np.log(0.2))
+    assert np.isclose(res["force_rmse"], np.log(0.3) * 0.5)
+    assert res["virial_rmse"] is None
+    assert task_result["virial_rmse"] is None
+
+
+def test_filter_generalizability_force_field_results_normalize():
+    task_result = {
+        "energy_rmse": 0.2,
+        "force_rmse": 0.4,
+    }
+    config = {
+        "energy_weight": 1.0,
+        "force_weight": 0.5,
+        "energy_std": 0.1,
+        "force_std": 0.2,
+    }
+    res = filter_generalizability_force_field_results(task_result, config, normalize=True)
+    assert np.isclose(res["energy_rmse"], 0.0)
+    assert np.isclose(res["force_rmse"], 0.0)
+
+
+def test_aggregated_inference_efficiency_results_complete():
+    data = {
+        "sys1": {"average_time": 0.1, "std_time": 0.01, "success_rate": 1.0},
+        "sys2": {"average_time": 0.2, "std_time": 0.04, "success_rate": 0.9},
+    }
+    res = aggregated_inference_efficiency_results(data)
+    expected_std = np.sqrt((0.01 ** 2 + 0.04 ** 2) / 2)
+    assert np.isclose(res["average_time"], 0.15)
+    assert np.isclose(res["standard_deviation"], expected_std)
+    assert np.isclose(res["success_rate"], 0.95)
+
+
+def test_aggregated_inference_efficiency_results_incomplete():
+    data = {
+        "sys1": {"average_time": None, "std_time": 0.01, "success_rate": 1.0},
+        "sys2": {"average_time": 0.2, "std_time": 0.04, "success_rate": 0.9},
+    }
+    res = aggregated_inference_efficiency_results(data)
+    assert res == {"average_time": None, "std_time": None, "success_rate": 0.0}
+
+
+def test_get_domain_to_direct_task_mapping():
+    config = {
+        "task1": {"domain": "A"},
+        "task2": {"domain": "B"},
+        "task3": {"domain": "A"},
+    }
+    res = get_domain_to_direct_task_mapping(config)
+    assert set(res["A"]) == {"task1", "task3"}
+    assert set(res["B"]) == {"task2"}

--- a/tests/tasks/calculator/test_inference_efficiency_extra.py
+++ b/tests/tasks/calculator/test_inference_efficiency_extra.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+import numpy as np
+import types
+import itertools
+
+from lambench.tasks.calculator.inference_efficiency.inference_efficiency import (
+    run_one_inference,
+    run_inference,
+)
+
+
+class DummyAtoms:
+    def __init__(self, n):
+        self.n = n
+
+    def repeat(self, factors):
+        return self
+
+    def get_cell_lengths_and_angles(self):
+        return np.array([1.0, 1.0, 1.0, 90.0, 90.0, 90.0])
+
+    def copy(self):
+        return self
+
+    def __len__(self):
+        return self.n
+
+    @property
+    def symbols(self):
+        return "H"
+
+
+def test_run_one_inference_success(monkeypatch):
+    dummy_atoms = [DummyAtoms(2), DummyAtoms(2)]
+
+    monkeypatch.setattr(
+        "lambench.tasks.calculator.inference_efficiency.inference_efficiency.read",
+        lambda p, s: dummy_atoms,
+    )
+    monkeypatch.setattr(
+        "lambench.tasks.calculator.inference_efficiency.inference_efficiency.binary_search_max_natoms",
+        lambda model, atoms, limit: 4,
+    )
+    monkeypatch.setattr(
+        "lambench.tasks.calculator.inference_efficiency.inference_efficiency.find_even_factors",
+        lambda n: (1, 1, 1),
+    )
+    monkeypatch.setattr(
+        "lambench.tasks.calculator.inference_efficiency.inference_efficiency.get_efv",
+        lambda atoms: None,
+    )
+    times = itertools.count(start=0, step=0.1)
+    monkeypatch.setattr(
+        "lambench.tasks.calculator.inference_efficiency.inference_efficiency.time.time",
+        lambda: next(times),
+    )
+
+    model = MagicMock()
+    model.calc.reset = MagicMock()
+
+    res = run_one_inference(model, Path("dummy"), 0.0, 10)
+    assert res["success_rate"] == 100.0
+    assert np.isclose(res["average_time"], 50000.0)
+    assert np.isclose(res["std_time"], 0.0)
+
+
+def test_run_inference(monkeypatch):
+    p1 = Path("a.traj")
+    p2 = Path("b.traj")
+    monkeypatch.setattr(Path, "rglob", lambda self, pattern: [p1, p2])
+
+    def mock_run_one(model, traj, w, n):
+        if traj == p1:
+            return {"average_time": 0.1, "std_time": 0.01, "success_rate": 100.0}
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(
+        "lambench.tasks.calculator.inference_efficiency.inference_efficiency.run_one_inference",
+        mock_run_one,
+    )
+
+    result = run_inference(MagicMock(), Path("test"), 0.0, 10)
+    assert result[p1.name]["average_time"] == 0.1
+    assert result[p1.name]["success_rate"] == 100.0
+    assert result[p2.name]["average_time"] is None
+    assert result[p2.name]["success_rate"] == 0.0

--- a/tests/tasks/finetune/test_property_finetune_utils.py
+++ b/tests/tasks/finetune/test_property_finetune_utils.py
@@ -1,0 +1,82 @@
+import json
+import os
+from pathlib import Path
+import logging
+from lambench.tasks.finetune.property_finetune import (
+    PropertyFinetuneTask,
+    FinetuneParams,
+)
+from lambench.models.dp_models import DPModel
+
+
+def test_find_value_by_key_pattern_found():
+    data = {"my_descriptor": {"activation_function": "relu"}, "other": 1}
+    result = PropertyFinetuneTask._find_value_by_key_pattern(data, "descriptor")
+    assert result == {"activation_function": "relu"}
+
+
+def test_find_value_by_key_pattern_missing(caplog):
+    data = {"foo": 1}
+    with caplog.at_level(logging.ERROR):
+        result = PropertyFinetuneTask._find_value_by_key_pattern(data, "descriptor")
+    assert result is None
+    assert "Descriptor not found" in caplog.text
+
+
+def test_prepare_property_directory(tmp_path):
+    pretrain_dir = tmp_path / "pretrain"
+    pretrain_dir.mkdir()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    train_dir = tmp_path / "train"
+    train_dir.mkdir()
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+
+    pretrain_config = {
+        "model": {
+            "shared_dict": {
+                "best_descriptor": {"activation_function": "gelu"},
+                "type_map_all": [0, 1],
+            }
+        }
+    }
+    with open(pretrain_dir / "input.json", "w") as f:
+        json.dump(pretrain_config, f)
+
+    model = DPModel(
+        model_name="m",
+        model_type="DP",
+        model_family="DP",
+        model_path=pretrain_dir / "model.ckpt",
+        virtualenv="",
+        model_metadata={
+            "pretty_name": "m",
+            "date_added": "2025-01-01",
+            "num_parameters": 1,
+            "packages": {"torch": "2.0.0"},
+        },
+    )
+
+    params = FinetuneParams()
+    task = PropertyFinetuneTask(
+        task_name="t",
+        property_name="prop",
+        intensive=True,
+        property_dim=1,
+        train_data=train_dir,
+        test_data=test_dir,
+        finetune_params=params,
+        workdir=workdir,
+    )
+
+    os.chdir(workdir)
+    task.prepare_property_directory(model)
+
+    with open(workdir / "input.json") as f:
+        cfg = json.load(f)
+
+    assert cfg["model"]["descriptor"] == pretrain_config["model"]["shared_dict"]["best_descriptor"]
+    assert "shared_dict" not in cfg["model"]
+    assert cfg["training"]["training_data"]["systems"] == str(train_dir)
+    assert cfg["training"]["validation_data"]["systems"] == str(test_dir)


### PR DESCRIPTION
## Summary
- add tests for searching descriptors and writing finetune config
- add tests for inference efficiency helper functions

## Testing
- `pytest -q tests/tasks/finetune/test_property_finetune_utils.py` *(fails: command not found)*
- `pytest -q tests/tasks/calculator/test_inference_efficiency_extra.py` *(fails: command not found)*