### PR TITLE
Fix: typo and missing info in metadata

### DIFF
--- a/lambench/metrics/results/metadata.json
+++ b/lambench/metrics/results/metadata.json
@@ -988,7 +988,7 @@
         "DESCRIPTION": "The mean absolute error of the energy barrier prediction across all OOD trajectories."
       },
       "MAE_dE": {
-        "DISPLAY_NAME": "MAE_dE (kcal/mol)",
+        "DISPLAY_NAME": "MAE_dE (eV)",
         "DESCRIPTION": "The mean absolute error of the reaction energy prediction across all OOD trajectories."
       },
       "ø_Desorption":{
@@ -1002,6 +1002,10 @@
       "ø_Transfer":{
         "DISPLAY_NAME": "% Transfer with Barrier Error > 0.1 eV",
         "DESCRIPTION": "The percentage of transfer reactions (total = 175) for which the model prediction of potential barrier height has an error of more than 0.1 eV."
+      },
+      "success_rate":{
+        "DISPLAY_NAME": "Success Rate",
+        "DESCRIPTION": "The success rate of NEB calculations."
       }
 
     },


### PR DESCRIPTION
This PR correct the unit and missing info in NEB task metadata.