### PR TITLE
fix: update dpdata dependency to point to the development branch

### DIFF
--- a/lambench/workflow/dflow.py
+++ b/lambench/workflow/dflow.py
@@ -12,6 +12,7 @@ from dflow import Task, Workflow
 from dflow.plugins.bohrium import BohriumDatasetsArtifact, create_job_group
 from dflow.plugins.dispatcher import DispatcherExecutor
 from dflow.python import OP, Artifact, PythonOPTemplate
+import dpdata
 
 import lambench
 from lambench.models.basemodel import BaseLargeAtomModel
@@ -58,7 +59,7 @@ def submit_tasks_dflow(
                 run_task_op,  # type: ignore
                 image=model.virtualenv,
                 envs={k: v for k, v in os.environ.items() if k.startswith("MYSQL")},
-                python_packages=[Path(package.__path__[0]) for package in [lambench]],
+                python_packages=[Path(package.__path__[0]) for package in [lambench, dpdata]],
             ),
             parameters={
                 "task": task,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 	"pyyaml",
 	"SQLAlchemy[pymysql]",
 	"tqdm",
-	"dpdata >= 0.2.22",
+	"dpdata @ git+https://github.com/deepmodeling/dpdata.git@devel#egg=dpdata",
 	"pandas",
 ]
 


### PR DESCRIPTION
This pull request introduces changes to integrate the `dpdata` library more effectively by switching its dependency source and including it in the `dflow` workflow. The updates ensure compatibility with the latest `dpdata` development branch and enable its usage within the task submission process.

### Dependency updates:
* Updated the `dpdata` dependency in `pyproject.toml` to point to the development branch of its GitHub repository instead of using a version constraint. (`[pyproject.tomlL16-R16](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L16-R16)`)

### Workflow enhancements:
* Imported the `dpdata` library in `lambench/workflow/dflow.py` to facilitate its usage in the workflow. (`[lambench/workflow/dflow.pyR15](diffhunk://#diff-ae7660d190c97c44721c44c5b4ac6500037e892c39739fda0aa1cb796cdb5506R15)`)
* Modified the `submit_tasks_dflow` function in `lambench/workflow/dflow.py` to include `dpdata` in the `python_packages` list, ensuring it is available in the execution environment. (`[lambench/workflow/dflow.pyL61-R62](diffhunk://#diff-ae7660d190c97c44721c44c5b4ac6500037e892c39739fda0aa1cb796cdb5506L61-R62)`)