### PR TITLE
Fix: update collision, H2combustion

### DIFF
--- a/lambench/metrics/direct_task_weights.yml
+++ b/lambench/metrics/direct_task_weights.yml
@@ -43,16 +43,16 @@ Collision:
   energy_weight: 1.0
   force_weight: 1.0
   virial_weight: null
-  energy_std: 0.4690509429726113
-  force_std: 1.9436163951047407
+  energy_std: 0.390200350320283
+  force_std: 2.021733350505997
   virial_std: null
 H_nature_2022:
   domain: Reactions
   energy_weight: 1.0
   force_weight: 1.0
   virial_weight: null
-  energy_std: 0.3915623031231297
-  force_std: 2.0571296230388896
+  energy_std: 0.34163860101107846
+  force_std: 2.056435289694542
   virial_std: null
 REANN_CO2_Ni100:
   domain: Catalysis

--- a/lambench/tasks/direct/direct_tasks.yml
+++ b/lambench/tasks/direct/direct_tasks.yml
@@ -9,9 +9,9 @@ HEMC_HEMB:
 MD22:
   test_data: "/bohr/lambench-ood-zwtr/v1/OOD_test_data_v2/MD22"
 Collision:
-  test_data: "/bohr/lambench-ood-zwtr/v1/OOD_test_data_v2/collision"
+  test_data: "/bohr/lambench-ood-pbe-m4bg/v5/Collision"
 H_nature_2022:
-  test_data: "/bohr/lambench-ood-zwtr/v1/OOD_test_data_v2/H_nature_2022"
+  test_data: "/bohr/lambench-ood-pbe-m4bg/v5/H_nature"
 REANN_CO2_Ni100:
   test_data: "/bohr/lambench-ood-zwtr/v1/OOD_test_data_v2/REANN_CO2_Ni100"
 NequIP_NC_2022:


### PR DESCRIPTION
This PR update OOD datasets, relabel H_nature_2022 (761 frames), collision (949 frames) with PBE. Both have fparam inputs.