### PR TITLE
feat: implement dft damping for ase calc

### DIFF
--- a/lambench/metrics/direct_task_weights.yml
+++ b/lambench/metrics/direct_task_weights.yml
@@ -35,8 +35,8 @@ MD22:
   energy_weight: 1.0
   force_weight: 1.0
   virial_weight: null
-  energy_std: 0.007941836149915322
-  force_std: 1.1391327961625524
+  energy_std: 0.008959619353114803
+  force_std: 1.1964522496892305
   virial_std: null
 REANN_CO2_Ni100:
   domain: Catalysis

--- a/lambench/metrics/results/metadata.json
+++ b/lambench/metrics/results/metadata.json
@@ -53,7 +53,7 @@
     },
     "MD22": {
       "DISPLAY_NAME": "MD22",
-      "DESCRIPTION": "Dataset containing MD trajectories of the 42-atom tetrapeptide Ac-Ala3-NHMe from the MD22 benchmark set. Calculations were performed using FHI-aims and i-Pi software at the DFT-PBE+MBD level of theory. Trajectories were sampled at temperatures between 400-500 K at 1 fs resolution. [https://www.science.org/doi/10.1126/sciadv.adf0873]",
+      "DESCRIPTION": "Dataset containing MD trajectories of the 42-atom tetrapeptide Ac-Ala3-NHMe from the MD22 benchmark set. Calculations were performed using FHI-aims and i-Pi software at the DFT-PBE+MBD level of theory. The dataset was relabeled using Gaussian with PBE/6-31G(d). Trajectories were sampled at temperatures between 400-500 K at 1 fs resolution. [https://www.science.org/doi/10.1126/sciadv.adf0873]",
       "domain": "Molecules",
       "energy_rmse": {
         "DISPLAY_NAME": "E RMSE (meV)",

--- a/lambench/models/ase_models.py
+++ b/lambench/models/ase_models.py
@@ -181,7 +181,7 @@ class ASEModel(BaseLargeAtomModel):
             import torch
 
             torch.set_default_dtype(torch.float32)
-            return self.run_ase_dptest(self, task.test_data, task.damping)
+            return self.run_ase_dptest(self, task.test_data, task.dispersion_correction)
         elif isinstance(task, CalculatorTask):
             if task.task_name == "nve_md":
                 from lambench.tasks.calculator.nve_md.nve_md import (
@@ -270,7 +270,7 @@ class ASEModel(BaseLargeAtomModel):
     def run_ase_dptest(
         model: ASEModel,
         test_data: Path,
-        damping: Literal["d3bj", "d3zero"] | None = None,
+        dispersion_correction: Literal["d3bj", "d3zero"] | None = None,
         # check all supported levels at dftd3.qcschema._available_levels
     ) -> dict:
         # Add fparam for charge and spin multiplicity if needed
@@ -284,8 +284,8 @@ class ASEModel(BaseLargeAtomModel):
         dpdata.LabeledSystem.register_data_type(datatype)
 
         calc = model.calc
-        if damping:
-            calc = SumCalculator([calc, DFTD3(method="PBE", damping=damping)])
+        if dispersion_correction:
+            calc = SumCalculator([calc, DFTD3(method="PBE", dispersion_correction=dispersion_correction)])
 
         energy_err = []
         energy_pre = []

--- a/lambench/models/ase_models.py
+++ b/lambench/models/ase_models.py
@@ -181,7 +181,7 @@ class ASEModel(BaseLargeAtomModel):
             import torch
 
             torch.set_default_dtype(torch.float32)
-            return self.run_ase_dptest(self, task.test_data)
+            return self.run_ase_dptest(self, task.test_data, task.damping)
         elif isinstance(task, CalculatorTask):
             if task.task_name == "nve_md":
                 from lambench.tasks.calculator.nve_md.nve_md import (

--- a/lambench/models/ase_models.py
+++ b/lambench/models/ase_models.py
@@ -285,7 +285,9 @@ class ASEModel(BaseLargeAtomModel):
 
         calc = model.calc
         if dispersion_correction:
-            calc = SumCalculator([calc, DFTD3(method="PBE", dispersion_correction=dispersion_correction)])
+            calc = SumCalculator(
+                [calc, DFTD3(method="PBE", dispersion_correction=dispersion_correction)]
+            )
 
         energy_err = []
         energy_pre = []

--- a/lambench/tasks/direct/direct_tasks.py
+++ b/lambench/tasks/direct/direct_tasks.py
@@ -12,8 +12,8 @@ class DirectPredictTask(BaseTask):
 
     record_type: ClassVar = DirectPredictRecord
     task_config: ClassVar = Path(__file__).parent / "direct_tasks.yml"
-    damping: Literal["d3bj", "d3zero"] | None = None
+    dispersion_correction: Literal["d3bj", "d3zero"] | None = None
 
     def __init__(self, task_name: str, **kwargs):
         super().__init__(task_name=task_name, test_data=kwargs["test_data"])
-        self.damping = kwargs.get("damping")
+        self.dispersion_correction = kwargs.get("dispersion_correction")

--- a/lambench/tasks/direct/direct_tasks.py
+++ b/lambench/tasks/direct/direct_tasks.py
@@ -13,6 +13,7 @@ class DirectPredictTask(BaseTask):
     record_type: ClassVar = DirectPredictRecord
     task_config: ClassVar = Path(__file__).parent / "direct_tasks.yml"
     damping: Literal["d3bj", "d3zero"] | None = None
+
     def __init__(self, task_name: str, **kwargs):
         super().__init__(task_name=task_name, test_data=kwargs["test_data"])
         self.damping = kwargs.get("damping")

--- a/lambench/tasks/direct/direct_tasks.py
+++ b/lambench/tasks/direct/direct_tasks.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Literal
 from lambench.tasks.base_task import BaseTask
 from lambench.databases.direct_predict_table import DirectPredictRecord
 
@@ -12,6 +12,7 @@ class DirectPredictTask(BaseTask):
 
     record_type: ClassVar = DirectPredictRecord
     task_config: ClassVar = Path(__file__).parent / "direct_tasks.yml"
-
+    damping: Literal["d3bj", "d3zero"] | None = None
     def __init__(self, task_name: str, **kwargs):
         super().__init__(task_name=task_name, test_data=kwargs["test_data"])
+        self.damping = kwargs.get("damping")

--- a/lambench/tasks/direct/direct_tasks.yml
+++ b/lambench/tasks/direct/direct_tasks.yml
@@ -1,29 +1,29 @@
 ANI:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/ANI"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/ANI"
 HEA25_S:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/HEA25S"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/HEA25S"
 HEA25_bulk:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/HEA25"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/HEA25"
 MoS2:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/MoS2"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/MoS2"
 MD22:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/MD22"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/MD22"
 REANN_CO2_Ni100:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/REANN_CO2_Ni100"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/REANN_CO2_Ni100"
 NequIP_NC_2022:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/NequIP_NC_2022"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/NequIP_NC_2022"
 AIMD-Chig:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/AIMD_chig"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/AIMD_chig"
 Cu_MgO_catalysts:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/Cu_MgO_CO2"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/Cu_MgO_CO2"
   dispersion_correction: d3zero
 Si_ZEO22:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/Si_ZEO22"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/Si_ZEO22"
   dispersion_correction: d3bj
 HPt_NC_2022:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/HPt_NC2022"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/HPt_NC2022"
 Ca_batteries_CM2021:
-  test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/Ca_batteries"
+  test_data: "/bohr/lambench-ood-zwtr/v4/LAMBench-TestData-v3/Ca_batteries"
 ## DEPRECATED
 # Collision:
 #   test_data: "/bohr/lambench-ood-zwtr/v2/LAMBench-TestData-v2/Collision"

--- a/lambench/tasks/direct/direct_tasks.yml
+++ b/lambench/tasks/direct/direct_tasks.yml
@@ -16,8 +16,10 @@ AIMD-Chig:
   test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/AIMD_chig"
 Cu_MgO_catalysts:
   test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/Cu_MgO_CO2"
+  dispersion_correction: d3zero
 Si_ZEO22:
   test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/Si_ZEO22"
+  dispersion_correction: d3bj
 HPt_NC_2022:
   test_data: "/bohr/lambench-ood-zwtr/v3/LAMBench-TestData-v3/HPt_NC2022"
 Ca_batteries_CM2021:

--- a/lambench/workflow/dflow.py
+++ b/lambench/workflow/dflow.py
@@ -12,7 +12,11 @@ from dflow import Task, Workflow
 from dflow.plugins.bohrium import BohriumDatasetsArtifact, create_job_group
 from dflow.plugins.dispatcher import DispatcherExecutor
 from dflow.python import OP, Artifact, PythonOPTemplate
+
 import dpdata
+import dftd3
+import cffi
+import pycparser
 
 import lambench
 from lambench.models.basemodel import BaseLargeAtomModel
@@ -60,7 +64,8 @@ def submit_tasks_dflow(
                 image=model.virtualenv,
                 envs={k: v for k, v in os.environ.items() if k.startswith("MYSQL")},
                 python_packages=[
-                    Path(package.__path__[0]) for package in [lambench, dpdata]
+                    Path(package.__path__[0])
+                    for package in [lambench, dpdata, dftd3, cffi, pycparser]
                 ],
             ),
             parameters={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 	"tqdm",
 	"dpdata @ git+https://github.com/deepmodeling/dpdata.git@devel#egg=dpdata",
 	"pandas",
+	"dftd3"
 ]
 
 authors = [

--- a/tests/metrics/test_visualization.py
+++ b/tests/metrics/test_visualization.py
@@ -14,7 +14,7 @@ def test_aggregate_ood_results_for_one_model(
     model.show_calculator_task = False
     aggregator = ResultsFetcher()
     result = aggregator.aggregate_ood_results_for_one_model(model=model)
-    np.testing.assert_almost_equal(result["Molecules"], 0.234724350, decimal=5)
+    np.testing.assert_almost_equal(result["Molecules"], desired=0.22748765, decimal=5)
     np.testing.assert_almost_equal(result["Inorganic Materials"], 0.2972349, decimal=5)
     assert result["Catalysis"] is None
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
This pull request adds support for applying DFT-D3 dispersion corrections with customizable damping options to the ASE-based evaluation workflow. The main changes introduce a `damping` parameter to relevant methods and classes, allowing users to specify the type of damping used in DFT-D3 corrections, and update the calculator setup accordingly.

**DFT-D3 Dispersion Correction Support:**

* Added a `damping` parameter (of type `Literal["d3bj", "d3zero"] | None`) to `DirectPredictTask` and the `run_ase_dptest` method, enabling the selection of DFT-D3 damping schemes or disabling them. (`lambench/tasks/direct/direct_tasks.py`, `lambench/models/ase_models.py`) [[1]](diffhunk://#diff-e798d352ad42ed3e6359bbb64e160da9763d41825ade0480503d16b81a1b01cbL2-R2) [[2]](diffhunk://#diff-e798d352ad42ed3e6359bbb64e160da9763d41825ade0480503d16b81a1b01cbL15-R18) [[3]](diffhunk://#diff-819d60f73d52770904af054b2a60bbca2d76f82bc3d8f7cb5be6c15b4887dc2fL268-R275)
* Modified the ASE model evaluation flow to pass the `damping` parameter from the task to the DFT-D3 setup. (`lambench/models/ase_models.py`)
* Updated the calculator instantiation in `run_ase_dptest` to use a `SumCalculator` that combines the original calculator with a DFTD3 correction if `damping` is specified. (`lambench/models/ase_models.py`)
* Added necessary imports for `SumCalculator` and `DFTD3` to support the new functionality. (`lambench/models/ase_models.py`)
* Updated type hints to include `Literal` for the new `damping` parameter. (`lambench/models/ase_models.py`, `lambench/tasks/direct/direct_tasks.py`) [[1]](diffhunk://#diff-819d60f73d52770904af054b2a60bbca2d76f82bc3d8f7cb5be6c15b4887dc2fL5-R5) [[2]](diffhunk://#diff-e798d352ad42ed3e6359bbb64e160da9763d41825ade0480503d16b81a1b01cbL2-R2)