### PR TITLE
Fix: NVEmd slope clip

### DIFF
--- a/lambench/metrics/utils.py
+++ b/lambench/metrics/utils.py
@@ -110,7 +110,7 @@ def aggregated_nve_md_results(results: dict[str, dict[str, float]]) -> dict[str,
     aggregated_result = {}
     success_count = len(results)
     for test_system, result in results.items():
-        if result["steps"] != NVEMD_NSTEPS:
+        if result["steps"] != NVEMD_NSTEPS or result["slope"]>=50:
             success_count -= 1
             continue  # Skip the incomplete simulation
         for k, v in result.items():

--- a/lambench/metrics/vishelper/metrics_calculations.py
+++ b/lambench/metrics/vishelper/metrics_calculations.py
@@ -190,10 +190,10 @@ class MetricsCalculator:
             return 5
         else:
             slope = cell.get("slope", None)
-            if slope is None:
+            if slope is None or np.log10(slope / lambda_0) >=5:
                 return 5
             else:
-                return np.clip(np.log10(cell["slope"] / lambda_0), a_min=0, a_max=None)
+                return np.clip(np.log10(slope / lambda_0), a_min=0, a_max=None)
 
     def calculate_efficiency_results(self) -> dict[str, float]:
         efficiency_results = self.fetcher.fetch_inference_efficiency_results()

--- a/tests/tasks/calculator/test_nve_md.py
+++ b/tests/tasks/calculator/test_nve_md.py
@@ -141,13 +141,13 @@ def test_aggregated_results():
         "Gd2Si4Ni2": {
             "simulation_time": 2374.1,
             "steps": 10000,
-            "slope": 4580.2,
+            "slope": 4.5802,
             "momenta_diff": 200020.2,
         },
     }
     result = aggregated_nve_md_results(results)
     np.testing.assert_almost_equal(result["simulation_time"], 2374.1, decimal=3)
     assert result["steps"] == 10000, "Should skip incomplete test."
-    assert result["slope"] == 4580.2, "Should skip incomplete test."
+    assert result["slope"] == 4.5802, "Should skip incomplete test."
     np.testing.assert_almost_equal(result["momenta_diff"], 200020.2, decimal=3)
     assert result["success_rate"] == 0.5, "Should have 1 success."


### PR DESCRIPTION
This PR add a upper limit to the slope. This change does not affect existing benchmark results. This fix is for an edge case where the NVE simulation finishes 10000 steps but has a significant energy drift, which will end up with a larger penalty.